### PR TITLE
Backport of 868a8b4f to 0.9.x - Optionally specify fixed 'now' to fetch

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -695,7 +695,7 @@ path is a string
   return info
 
 
-def fetch(path,fromTime,untilTime=None):
+def fetch(path,fromTime,untilTime=None,now=None):
   """fetch(path,fromTime,untilTime=None)
 
 path is a string
@@ -708,12 +708,13 @@ where timeInfo is itself a tuple of (fromTime, untilTime, step)
 Returns None if no data can be returned
 """
   fh = open(path,'rb')
-  return file_fetch(fh, fromTime, untilTime)
+  return file_fetch(fh, fromTime, untilTime,now)
 
 
-def file_fetch(fh, fromTime, untilTime):
+def file_fetch(fh, fromTime, untilTime, now = None):
   header = __readHeader(fh)
-  now = int( time.time() )
+  if now is None:
+    now = int( time.time() )
   if untilTime is None:
     untilTime = now
   fromTime = int(fromTime)


### PR DESCRIPTION
This backport is required for the 0.9.x branch of graphite-web to be compatible with the 0.9.x branch of carbon.
